### PR TITLE
App List: Comparator ordering fix.

### DIFF
--- a/app/src/main/java/com/njlabs/showjava/ui/AppListing.java
+++ b/app/src/main/java/com/njlabs/showjava/ui/AppListing.java
@@ -164,7 +164,7 @@ public class AppListing extends BaseActivity {
         }
         Comparator<PackageInfoHolder> AppNameComparator = new Comparator<PackageInfoHolder>() {
             public int compare(PackageInfoHolder o1, PackageInfoHolder o2) {
-                return o1.getPackageLabel().compareTo(o2.getPackageLabel());
+                return o1.getPackageLabel().toLowerCase().compareTo(o2.getPackageLabel().toLowerCase());
             }
         };
         Collections.sort(res, AppNameComparator);


### PR DESCRIPTION
Comparator is case sensitive, apps starting with lowercase names (rare, but still 2 out of my 217 installed ones), get pushed to the bottom of the list.
This fixes the problems by forcing case sensitivity to go out the window.